### PR TITLE
feat: explode zone.masq with ipv4/6 fullcone switch

### DIFF
--- a/root/etc/config/firewall
+++ b/root/etc/config/firewall
@@ -5,6 +5,7 @@ config defaults
 	option forward		REJECT
 # Uncomment this line to disable ipv6 rules
 #	option disable_ipv6	1
+	option fullcone '1'
 
 config zone
 	option name		lan
@@ -20,6 +21,7 @@ config zone
 	option input		REJECT
 	option output		ACCEPT
 	option forward		REJECT
+	option fullcone '1'
 	option masq		1
 	option mtu_fix		1
 

--- a/root/usr/share/firewall4/templates/ruleset.uc
+++ b/root/usr/share/firewall4/templates/ruleset.uc
@@ -240,7 +240,8 @@ table inet fw4 {
 		{%+ include("redirect.uc", { fw4, redirect }) %}
 {%   endfor %}
 {%   if (zone.fullcone): %}
-		{%+ include("zone-fullcone.uc", { fw4, zone, direction: "dstnat" }) %}
+		{%+ include("zone-fullcone.uc", { fw4, zone, family: 4, direction: "srcnat" }) %}
+		{%+ include("zone-fullcone.uc", { fw4, zone, family: 6, direction: "srcnat" }) %}
 {%   endif %}
 	}
 
@@ -264,8 +265,11 @@ table inet fw4 {
 {%     endfor %}
 {%    endfor %}
 {%   endif %}
-{%   if (zone.fullcone): %}
-		{%+ include("zone-fullcone.uc", { fw4, zone, direction: "srcnat" }) %}
+{%   if (zone.masq && zone.fullcone): %}
+		{%+ include("zone-fullcone.uc", { fw4, zone, family: 4, direction: "srcnat" }) %}
+{%   endif %}
+{%   if (zone.masq6 && zone.fullcone): %}
+		{%+ include("zone-fullcone.uc", { fw4, zone, family: 6, direction: "srcnat" }) %}
 {%   endif %}
 	}
 

--- a/root/usr/share/firewall4/templates/ruleset.uc
+++ b/root/usr/share/firewall4/templates/ruleset.uc
@@ -239,9 +239,11 @@ table inet fw4 {
 {%   for (let redirect in fw4.redirects(`dstnat_${zone.name}`)): %}
 		{%+ include("redirect.uc", { fw4, redirect }) %}
 {%   endfor %}
-{%   if (zone.fullcone): %}
-		{%+ include("zone-fullcone.uc", { fw4, zone, family: 4, direction: "srcnat" }) %}
-		{%+ include("zone-fullcone.uc", { fw4, zone, family: 6, direction: "srcnat" }) %}
+{%   if (zone.masq && zone.fullcone): %}
+		{%+ include("zone-fullcone.uc", { fw4, zone, family: 4, direction: "dstnat" }) %}
+{%   endif %}
+{%   if (zone.masq6 && zone.fullcone): %}
+		{%+ include("zone-fullcone.uc", { fw4, zone, family: 6, direction: "dstnat" }) %}
 {%   endif %}
 	}
 

--- a/root/usr/share/firewall4/templates/ruleset.uc
+++ b/root/usr/share/firewall4/templates/ruleset.uc
@@ -1,3 +1,4 @@
+{# /usr/share/firewall4/templates/ruleset.uc #}
 {% let flowtable_devices = fw4.resolve_offload_devices(); -%}
 
 table inet fw4
@@ -238,6 +239,9 @@ table inet fw4 {
 {%   for (let redirect in fw4.redirects(`dstnat_${zone.name}`)): %}
 		{%+ include("redirect.uc", { fw4, redirect }) %}
 {%   endfor %}
+{%   if (zone.fullcone): %}
+		{%+ include("zone-fullcone.uc", { fw4, zone, direction: "dstnat" }) %}
+{%   endif %}
 	}
 
 {%  endif %}
@@ -246,19 +250,22 @@ table inet fw4 {
 {%   for (let redirect in fw4.redirects(`srcnat_${zone.name}`)): %}
 		{%+ include("redirect.uc", { fw4, redirect }) %}
 {%   endfor %}
-{%   if (zone.masq): %}
+{%   if (zone.masq && !zone.fullcone): %}
 {%    for (let saddrs in zone.masq4_src_subnets): %}
 {%     for (let daddrs in zone.masq4_dest_subnets): %}
 		{%+ include("zone-masq.uc", { fw4, zone, family: 4, saddrs, daddrs }) %}
 {%     endfor %}
 {%    endfor %}
 {%   endif %}
-{%   if (zone.masq6): %}
+{%   if (zone.masq6 && !zone.fullcone): %}
 {%    for (let saddrs in zone.masq6_src_subnets): %}
 {%     for (let daddrs in zone.masq6_dest_subnets): %}
 		{%+ include("zone-masq.uc", { fw4, zone, family: 6, saddrs, daddrs }) %}
 {%     endfor %}
 {%    endfor %}
+{%   endif %}
+{%   if (zone.fullcone): %}
+		{%+ include("zone-fullcone.uc", { fw4, zone, direction: "srcnat" }) %}
 {%   endif %}
 	}
 

--- a/root/usr/share/firewall4/templates/zone-fullcone.uc
+++ b/root/usr/share/firewall4/templates/zone-fullcone.uc
@@ -1,0 +1,4 @@
+{# /usr/share/firewall4/templates/zone-fullcone.uc #}
+		fullcone comment "!fw4: Handle {{
+		zone.name
+}} IPv4/IPv6 fullcone NAT traffic"

--- a/root/usr/share/firewall4/templates/zone-fullcone.uc
+++ b/root/usr/share/firewall4/templates/zone-fullcone.uc
@@ -1,4 +1,4 @@
 {# /usr/share/firewall4/templates/zone-fullcone.uc #}
-		fullcone comment "!fw4: Handle {{
-		zone.name
-}} IPv4/IPv6 fullcone NAT traffic"
+		meta nfproto {{ fw4.nfproto(family) }} fullcone comment "!fw4: Handle {{ zone.name }} {{
+		fw4.nfproto(family, true)
+}} {{ direction }} fullcone NAT traffic"


### PR DESCRIPTION
Whether fullcone is enabled for ipv4 and ipv6 should depend on masquerade. If ipv6 has subnet address assignment, fullcone should not be enabled.